### PR TITLE
Improve Docker docs and CI summaries

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,5 +39,9 @@ jobs:
           echo '' >> "$GITHUB_STEP_SUMMARY"
           echo '```bash' >> "$GITHUB_STEP_SUMMARY"
           echo "docker pull $IMAGE" >> "$GITHUB_STEP_SUMMARY"
+          echo "docker run --rm -p 3000:3000 $IMAGE" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo 'Images are built for the linux/amd64 platform.' >> "$GITHUB_STEP_SUMMARY"
+          echo 'On Apple Silicon, add `--platform linux/amd64` to the run command.' >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,5 +13,16 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - run: cargo test --verbose
+      - name: Run tests
+        run: cargo test --verbose | tee test.log
+      - name: Test summary
+        if: always()
+        run: |
+          echo "### Test Results" >> "$GITHUB_STEP_SUMMARY"
+          grep '^test ' test.log >> "$GITHUB_STEP_SUMMARY" || true
+          grep '^test result:' test.log >> "$GITHUB_STEP_SUMMARY" || true
+          if grep -q '^failures:' test.log; then
+            echo '' >> "$GITHUB_STEP_SUMMARY"
+            sed -n '/^failures:/,/^test result:/p' test.log >> "$GITHUB_STEP_SUMMARY"
+          fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,23 @@ jobs:
         if: always()
         run: |
           echo "### Test Results" >> "$GITHUB_STEP_SUMMARY"
-          grep '^test ' test.log >> "$GITHUB_STEP_SUMMARY" || true
-          grep '^test result:' test.log >> "$GITHUB_STEP_SUMMARY" || true
+          awk '/^test .* \.{3}/ {printf "| `%s` | %s |\n", $2, $NF}' test.log > table.tmp
+          if [ -s table.tmp ]; then
+            {
+              echo "| Test | Result |"
+              echo "| ---- | ------ |"
+              cat table.tmp
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          summary=$(grep '^test result:' test.log | tail -n1)
+          if [ -n "$summary" ]; then
+            echo '' >> "$GITHUB_STEP_SUMMARY"
+            echo "\`$summary\`" >> "$GITHUB_STEP_SUMMARY"
+          fi
           if grep -q '^failures:' test.log; then
             echo '' >> "$GITHUB_STEP_SUMMARY"
+            echo '<details><summary>Failures</summary>' >> "$GITHUB_STEP_SUMMARY"
             sed -n '/^failures:/,/^test result:/p' test.log >> "$GITHUB_STEP_SUMMARY"
+            echo '</details>' >> "$GITHUB_STEP_SUMMARY"
           fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM rust:1 as builder
+FROM rust:1-bullseye as builder
 WORKDIR /usr/src/app
 COPY . .
 RUN cargo install --path . --locked

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ docker pull ghcr.io/<github-user>/rust-fantasy-finance:<tag>
 docker run --rm -p 3000:3000 ghcr.io/<github-user>/rust-fantasy-finance:<tag>
 ```
 
+The published images target the `linux/amd64` platform and run on any x86_64
+system with Docker. If you're on an Apple Silicon Mac, add
+`--platform linux/amd64` to the `docker run` command:
+
+```bash
+docker run --rm -p 3000:3000 --platform linux/amd64 \
+  ghcr.io/<github-user>/rust-fantasy-finance:<tag>
+```
+
 ## GitHub Actions
 
 Two workflows are provided:


### PR DESCRIPTION
## Summary
- clarify that the image targets linux/amd64 and show how Apple Silicon users can run it
- include run instructions and platform note in Docker workflow summary
- add a test summary step that reports executed tests and timing

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68477ab27ab48320867d13a9bf3bc2dc