### PR TITLE
Improve Mac docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ docker run --rm -p 3000:3000 ghcr.io/<github-user>/rust-fantasy-finance:<tag>
 
 The published images target the `linux/amd64` platform and run on any x86_64
 system with Docker. If you're on an Apple Silicon Mac, add
-`--platform linux/amd64` to the `docker run` command:
+`--platform linux/amd64` **immediately after** `docker run` and before the image
+name:
 
 ```bash
 docker run --rm -p 3000:3000 --platform linux/amd64 \


### PR DESCRIPTION
## Summary
- clarify placement of `--platform` flag when running the docker image on Apple Silicon Macs

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68477eaf2b0c8320970abbf89423b245