### PR TITLE
Improve error messages for holdings service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "arrow-array"
 version = "55.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1039,7 @@ dependencies = [
 name = "rust_fantasy_finance"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "arrow-array",
  "arrow-schema",
  "axum",
@@ -1040,15 +1047,16 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror",
  "tokio",
  "tower 0.4.13",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc_version"
@@ -1207,9 +1215,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1233,6 +1241,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ serde_json = "1"
 arrow-array = "55.1"
 arrow-schema = "55.1"
 parquet = "55.1"
+thiserror = "1"
+anyhow = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,45 @@
+use axum::{response::{IntoResponse, Response}, http::StatusCode, Json};
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+struct ErrorMessage {
+    error: String,
+}
+
+#[derive(Debug)]
+pub struct AppError {
+    pub status: StatusCode,
+    pub message: String,
+}
+
+impl AppError {
+    pub fn new(status: StatusCode, message: impl Into<String>) -> Self {
+        Self { status, message: message.into() }
+    }
+
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::INTERNAL_SERVER_ERROR, message)
+    }
+
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::NOT_FOUND, message)
+    }
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let body = Json(ErrorMessage { error: self.message });
+        (self.status, body).into_response()
+    }
+}
+
+impl From<crate::holdings::StoreError> for AppError {
+    fn from(err: crate::holdings::StoreError) -> Self {
+        match err {
+            crate::holdings::StoreError::NoOrders(user) => {
+                AppError::not_found(format!("no orders for user {user}"))
+            }
+            crate::holdings::StoreError::Other(e) => AppError::internal(e.to_string()),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add AppError type for structured HTTP error responses
- surface specific storage errors from HoldingStore
- upgrade endpoints to return Result with AppError
- introduce StoreError and use anyhow/thiserror for better messages

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6847cfe138f48320b719659380c00ee0