### PR TITLE
Improve code structure and add helpers

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,14 @@
 use axum::{response::{IntoResponse, Response}, http::StatusCode, Json};
 use serde::Serialize;
+use thiserror::Error;
 
 #[derive(Debug, Serialize)]
 struct ErrorMessage {
     error: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
+#[error("{message}")]
 pub struct AppError {
     pub status: StatusCode,
     pub message: String,

--- a/src/holdings.rs
+++ b/src/holdings.rs
@@ -22,6 +22,55 @@ pub struct Order {
     pub price: f64,
 }
 
+fn order_schema() -> arrow_schema::Schema {
+    use arrow_schema::{DataType, Field, Schema};
+    Schema::new(vec![
+        Field::new("user", DataType::Utf8, false),
+        Field::new("symbol", DataType::Utf8, false),
+        Field::new("amount", DataType::Int64, false),
+        Field::new("price", DataType::Float64, false),
+    ])
+}
+
+fn orders_to_record_batch(orders: &[Order]) -> anyhow::Result<arrow_array::RecordBatch> {
+    use arrow_array::{Float64Array, Int64Array, RecordBatch, StringArray};
+    use std::sync::Arc as SyncArc;
+
+    let schema = SyncArc::new(order_schema());
+    let user_array = StringArray::from_iter_values(orders.iter().map(|o| o.user.as_str()));
+    let symbol_array = StringArray::from_iter_values(orders.iter().map(|o| o.symbol.as_str()));
+    let amount_array = Int64Array::from_iter_values(orders.iter().map(|o| o.amount));
+    let price_array = Float64Array::from_iter_values(orders.iter().map(|o| o.price));
+
+    Ok(RecordBatch::try_new(
+        schema,
+        vec![
+            SyncArc::new(user_array),
+            SyncArc::new(symbol_array),
+            SyncArc::new(amount_array),
+            SyncArc::new(price_array),
+        ],
+    )?)
+}
+
+fn batch_to_orders(batch: &arrow_array::RecordBatch) -> Vec<Order> {
+    use arrow_array::{Float64Array, Int64Array, StringArray};
+
+    let user_array = batch.column(0).as_any().downcast_ref::<StringArray>().unwrap();
+    let symbol_array = batch.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+    let amount_array = batch.column(2).as_any().downcast_ref::<Int64Array>().unwrap();
+    let price_array = batch.column(3).as_any().downcast_ref::<Float64Array>().unwrap();
+
+    (0..batch.num_rows())
+        .map(|i| Order {
+            user: user_array.value(i).to_string(),
+            symbol: symbol_array.value(i).to_string(),
+            amount: amount_array.value(i),
+            price: price_array.value(i),
+        })
+        .collect()
+}
+
 #[derive(Clone)]
 pub struct HoldingStore {
     data_dir: PathBuf,
@@ -78,11 +127,8 @@ impl HoldingStore {
     }
 
     async fn write_user_file(&self, user: &str) -> anyhow::Result<()> {
-        use arrow_array::{RecordBatch, StringArray, Int64Array, Float64Array};
-        use arrow_schema::{Field, Schema, DataType};
         use parquet::arrow::ArrowWriter;
-        use std::fs::{File, create_dir_all};
-        use std::sync::Arc as SyncArc;
+        use std::fs::{create_dir_all, File};
 
         let _lock = self.fs_lock.lock().await;
 
@@ -90,42 +136,20 @@ impl HoldingStore {
         create_dir_all(&user_dir)?;
         let file_path = user_dir.join("orders.parquet");
 
-        let schema = Schema::new(vec![
-            Field::new("user", DataType::Utf8, false),
-            Field::new("symbol", DataType::Utf8, false),
-            Field::new("amount", DataType::Int64, false),
-            Field::new("price", DataType::Float64, false),
-        ]);
-        let schema = SyncArc::new(schema);
-
         let map = self.inner.read().await;
         let orders = map.get(user).cloned().unwrap_or_default();
         drop(map);
 
-        let user_array = StringArray::from_iter_values(orders.iter().map(|o| o.user.as_str()));
-        let symbol_array = StringArray::from_iter_values(orders.iter().map(|o| o.symbol.as_str()));
-        let amount_array = Int64Array::from_iter_values(orders.iter().map(|o| o.amount));
-        let price_array = Float64Array::from_iter_values(orders.iter().map(|o| o.price));
-
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![
-                SyncArc::new(user_array),
-                SyncArc::new(symbol_array),
-                SyncArc::new(amount_array),
-                SyncArc::new(price_array),
-            ],
-        )?;
+        let batch = orders_to_record_batch(&orders)?;
 
         let file = File::create(file_path)?;
-        let mut writer = ArrowWriter::try_new(file, schema, None)?;
+        let mut writer = ArrowWriter::try_new(file, batch.schema(), None)?;
         writer.write(&batch)?;
         writer.close()?;
         Ok(())
     }
 
     async fn read_user_file(&self, user: &str) -> anyhow::Result<Vec<Order>> {
-        use arrow_array::{Float64Array, Int64Array, StringArray};
         use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
         use std::fs::File;
 
@@ -141,19 +165,7 @@ impl HoldingStore {
         let mut orders = Vec::new();
         while let Some(batch) = reader.next() {
             let batch = batch?;
-            let user_array = batch.column(0).as_any().downcast_ref::<StringArray>().unwrap();
-            let symbol_array = batch.column(1).as_any().downcast_ref::<StringArray>().unwrap();
-            let amount_array = batch.column(2).as_any().downcast_ref::<Int64Array>().unwrap();
-            let price_array = batch.column(3).as_any().downcast_ref::<Float64Array>().unwrap();
-
-            for i in 0..batch.num_rows() {
-                orders.push(Order {
-                    user: user_array.value(i).to_string(),
-                    symbol: symbol_array.value(i).to_string(),
-                    amount: amount_array.value(i),
-                    price: price_array.value(i),
-                });
-            }
+            orders.extend(batch_to_orders(&batch));
         }
         Ok(orders)
     }
@@ -170,5 +182,46 @@ pub struct OrderRequest {
 impl From<OrderRequest> for Order {
     fn from(req: OrderRequest) -> Self {
         Order { user: req.user, symbol: req.symbol, amount: req.amount, price: req.price }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_order_schema_fields() {
+        let schema = order_schema();
+        let names: Vec<_> = schema.fields().iter().map(|f| f.name()).collect();
+        assert_eq!(names, ["user", "symbol", "amount", "price"]);
+    }
+
+    #[test]
+    fn test_batch_round_trip() {
+        let orders = vec![
+            Order { user: "alice".into(), symbol: "AAPL".into(), amount: 1, price: 10.0 },
+            Order { user: "bob".into(), symbol: "MSFT".into(), amount: 2, price: 20.0 },
+        ];
+
+        let batch = orders_to_record_batch(&orders).unwrap();
+        assert_eq!(batch.num_rows(), 2);
+
+        let restored = batch_to_orders(&batch);
+        assert_eq!(orders, restored);
+    }
+
+    #[tokio::test]
+    async fn test_persist_round_trip() {
+        let dir = tempdir().unwrap();
+        let store = HoldingStore::new(dir.path().to_path_buf());
+
+        let order = Order { user: "alice".into(), symbol: "AAPL".into(), amount: 1, price: 10.0 };
+        store.add_order(order.clone()).await.unwrap();
+
+        // use a fresh store to ensure data comes from disk
+        let store2 = HoldingStore::new(dir.path().to_path_buf());
+        let loaded = store2.orders_for_user("alice").await.unwrap();
+        assert_eq!(loaded, vec![order]);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod holdings;
 mod error;
 mod market;
+mod state;
 
 use axum::{routing::{get, post}, Router, response::IntoResponse, extract::{Path, State}, Json};
 use tokio::net::TcpListener;
@@ -9,12 +10,8 @@ use std::sync::Arc;
 use holdings::{HoldingStore, OrderRequest};
 use market::{MarketData, YahooFetcher};
 use error::AppError;
+use state::AppState;
 
-#[derive(Clone)]
-struct AppState {
-    store: HoldingStore,
-    market: Arc<MarketData>,
-}
 
 async fn hello() -> impl IntoResponse {
     "Hello, world!"
@@ -79,6 +76,7 @@ mod tests {
     use axum::http::{Request, StatusCode};
     use holdings::Order;
     use market::{MarketData, QuoteFetcher};
+    use state::AppState;
     use async_trait::async_trait;
     use yahoo_finance_api::Quote;
     use tower::ServiceExt; // for `oneshot`

--- a/src/market.rs
+++ b/src/market.rs
@@ -51,6 +51,8 @@ pub struct MarketData {
     inner: Arc<RwLock<HashMap<String, PriceInfo>>>,
 }
 
+const UPDATE_INTERVAL_SECS: u64 = 30;
+
 impl MarketData {
     pub fn new(fetcher: Arc<dyn QuoteFetcher>) -> Self {
         Self { fetcher, inner: Arc::new(RwLock::new(HashMap::new())) }
@@ -92,7 +94,7 @@ impl MarketData {
         use tokio::time::{sleep, Duration};
         loop {
             let _ = self.update(&store).await;
-            sleep(Duration::from_secs(30)).await;
+            sleep(Duration::from_secs(UPDATE_INTERVAL_SECS)).await;
         }
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,10 @@
+use std::sync::Arc;
+
+use crate::holdings::HoldingStore;
+use crate::market::MarketData;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub store: HoldingStore,
+    pub market: Arc<MarketData>,
+}


### PR DESCRIPTION
## Summary
- move `AppState` to its own module
- derive `thiserror::Error` on `AppError`
- introduce `UPDATE_INTERVAL_SECS` constant for market updates
- add helper functions for Arrow serialization
- add unit tests for Arrow helpers

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6847f0ec371c83208abee94932aac8a4