### PR TITLE
Add daily close persistence and 2-minute market updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,9 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -1466,6 +1468,7 @@ dependencies = [
  "arrow-schema",
  "async-trait",
  "axum",
+ "chrono",
  "parquet",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ thiserror = "1"
 anyhow = "1"
 yahoo_finance_api = "4"
 async-trait = "0.1"
+chrono = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ async fn market_prices(State(state): State<AppState>) -> impl IntoResponse {
 async fn main() {
     let store = HoldingStore::new(PathBuf::from("data"));
     let fetcher = Arc::new(YahooFetcher::new().expect("failed to create fetcher"));
-    let market = Arc::new(MarketData::new(fetcher));
+    let market = Arc::new(MarketData::new(fetcher, PathBuf::from("data/market")));
 
     let state = AppState { store: store.clone(), market: market.clone() };
 
@@ -109,7 +109,8 @@ mod tests {
                 Ok(Vec::new())
             }
         }
-        let market = Arc::new(MarketData::new(Arc::new(DummyFetcher)));
+        let market_dir = dir.path().join("market");
+        let market = Arc::new(MarketData::new(Arc::new(DummyFetcher), market_dir));
         let state = AppState { store: store.clone(), market };
         let app = Router::new()
             .route("/holdings/transaction", post(add_transaction))
@@ -177,7 +178,8 @@ mod tests {
                 Ok(Vec::new())
             }
         }
-        let market = Arc::new(MarketData::new(Arc::new(DummyFetcher)));
+        let market_dir = dir.path().join("market");
+        let market = Arc::new(MarketData::new(Arc::new(DummyFetcher), market_dir));
         let state = AppState { store: store.clone(), market };
         let app = Router::new()
             .route("/holdings/transaction", post(add_transaction))
@@ -217,7 +219,8 @@ mod tests {
             }
         }
 
-        let market = Arc::new(MarketData::new(Arc::new(MockFetcher)));
+        let market_dir = dir.path().join("market");
+        let market = Arc::new(MarketData::new(Arc::new(MockFetcher), market_dir));
         let state = AppState { store: store.clone(), market: market.clone() };
         market.update(&store).await.unwrap();
 


### PR DESCRIPTION
## Summary
- persist daily closing prices to `data/market/<symbol>/prices.parquet`
- update `MarketData` refresh interval to 2 minutes
- adjust API and tests for the new `MarketData::new` signature
- add `chrono` dependency for timestamp handling

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684800bb7af88320a60a683cbcef2ecd