### PR TITLE
Add market symbols endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ This project is a minimal REST API built with [Axum](https://github.com/tokio-rs
 - `GET /holdings/orders` – list all recorded transactions.
 - `GET /holdings/orders/<user>` – list transactions for a specific user. Returns `404` if the user has no orders stored.
 - `GET /market/prices` – current price for each symbol held by any user.
+- `GET /market/symbols` – list of all symbols currently tracked.
 
 Transactions are kept in memory and flushed to Parquet files under `data/<user>/orders.parquet`.
 Market prices are periodically fetched from Yahoo Finance for all symbols found in those orders and served via `/market/prices`. Closing prices are stored under `data/market/<symbol>/prices.parquet` and refreshed every two minutes.
+The list of tracked symbols can be retrieved from `/market/symbols`.
 
 #### Example requests
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,12 @@ async fn market_prices(State(state): State<AppState>) -> impl IntoResponse {
     Json(prices)
 }
 
+async fn market_symbols(State(state): State<AppState>) -> impl IntoResponse {
+    let mut symbols = state.market.symbols().await;
+    symbols.sort();
+    Json(symbols)
+}
+
 #[tokio::main]
 async fn main() {
     let store = HoldingStore::new(PathBuf::from("data"));
@@ -63,6 +69,7 @@ async fn main() {
         .route("/holdings/orders", get(list_orders))
         .route("/holdings/orders/:user", get(list_orders_for_user))
         .route("/market/prices", get(market_prices))
+        .route("/market/symbols", get(market_symbols))
         .with_state(state);
 
     let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();
@@ -236,5 +243,41 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let prices: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(prices["AAPL"], 10.0);
+    }
+
+    #[tokio::test]
+    async fn test_market_symbols_endpoint() {
+        let dir = tempdir().unwrap();
+        let store = HoldingStore::new(dir.path().to_path_buf());
+        store
+            .add_order(Order { user: "alice".into(), symbol: "AAPL".into(), amount: 1, price: 1.0 })
+            .await
+            .unwrap();
+
+        struct MockFetcher;
+        #[async_trait]
+        impl QuoteFetcher for MockFetcher {
+            async fn fetch_quotes(&self, _symbol: &str) -> anyhow::Result<Vec<Quote>> {
+                Ok(vec![Quote { timestamp: 0, open: 10.0, high: 10.0, low: 10.0, volume: 0, close: 10.0, adjclose: 10.0 }])
+            }
+        }
+
+        let market_dir = dir.path().join("market");
+        let market = Arc::new(MarketData::new(Arc::new(MockFetcher), market_dir));
+        let state = AppState { store: store.clone(), market: market.clone() };
+        market.update(&store).await.unwrap();
+
+        let app = Router::new()
+            .route("/market/symbols", get(market_symbols))
+            .with_state(state);
+
+        let response = app
+            .oneshot(Request::builder().uri("/market/symbols").body(axum::body::Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let symbols: Vec<String> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(symbols, vec!["AAPL"]);
     }
 }


### PR DESCRIPTION
## Summary
- expose `/market/symbols` to list tracked symbols
- test the new endpoint and ensure the symbols API works
- document the `/market/symbols` route in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6848ccd241dc8320bce4ad055a183008