### PR TITLE
Add holdings service with price updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
   `.github/actions/version`.
 
  - The service exposes `POST /holdings/transaction`, `GET /holdings/orders`,
-   `GET /holdings/orders/<user>`, and `GET /market/prices`. Transactions are stored in memory and
+   `GET /holdings/orders/<user>`, `GET /holdings`, and `GET /market/prices`. Transactions are stored in memory and
   persisted to Parquet files under `data/<user>/orders.parquet`. Market data is refreshed every two
   minutes and daily closes are appended to `data/market/<symbol>/prices.parquet`.
   Tests should avoid relying on network access and use temporary directories when touching

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,6 +864,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "lexical-core"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,6 +1042,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,6 +1154,12 @@ checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1476,6 +1498,8 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tower 0.4.13",
+ "tracing",
+ "tracing-subscriber",
  "yahoo_finance_api",
 ]
 
@@ -1633,6 +1657,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1784,6 +1817,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -1970,7 +2013,19 @@ checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1980,6 +2035,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2032,6 +2113,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -2162,6 +2249,28 @@ checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ anyhow = "1"
 yahoo_finance_api = "4"
 async-trait = "0.1"
 chrono = "0.4"
+tracing = "0.1"
+tracing-subscriber = "0.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ This project is a minimal REST API built with [Axum](https://github.com/tokio-rs
 - `POST /holdings/transaction` – add a transaction in JSON with `user`, `symbol`, `amount` and `price`.
 - `GET /holdings/orders` – list all recorded transactions.
 - `GET /holdings/orders/<user>` – list transactions for a specific user. Returns `404` if the user has no orders stored.
+- `GET /holdings` – list holdings. Accepts optional `user` query parameter to filter by user.
 - `GET /market/prices` – current price for each symbol held by any user.
 
 Transactions are kept in memory and flushed to Parquet files under `data/<user>/orders.parquet`.
 Market prices are periodically fetched from Yahoo Finance for all symbols found in those orders and served via `/market/prices`. Closing prices are stored under `data/market/<symbol>/prices.parquet` and refreshed every two minutes.
+Holdings are updated at the same time, recording the latest price for each user order.
 
 #### Example requests
 
@@ -22,6 +24,8 @@ curl -X POST http://localhost:3000/holdings/transaction \
 curl http://localhost:3000/holdings/orders
 
 curl http://localhost:3000/holdings/orders/alice
+
+curl http://localhost:3000/holdings?user=alice
 ```
 
 ## Running locally

--- a/postman_collection.json
+++ b/postman_collection.json
@@ -11,7 +11,9 @@
         "url": {
           "raw": "http://localhost:3000/",
           "protocol": "http",
-          "host": ["localhost"],
+          "host": [
+            "localhost"
+          ],
           "port": "3000"
         }
       }
@@ -21,7 +23,10 @@
       "request": {
         "method": "POST",
         "header": [
-          {"key": "Content-Type", "value": "application/json"}
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
         ],
         "body": {
           "mode": "raw",
@@ -30,9 +35,14 @@
         "url": {
           "raw": "http://localhost:3000/holdings/transaction",
           "protocol": "http",
-          "host": ["localhost"],
+          "host": [
+            "localhost"
+          ],
           "port": "3000",
-          "path": ["holdings", "transaction"]
+          "path": [
+            "holdings",
+            "transaction"
+          ]
         }
       }
     },
@@ -43,9 +53,14 @@
         "url": {
           "raw": "http://localhost:3000/holdings/orders",
           "protocol": "http",
-          "host": ["localhost"],
+          "host": [
+            "localhost"
+          ],
           "port": "3000",
-          "path": ["holdings", "orders"]
+          "path": [
+            "holdings",
+            "orders"
+          ]
         }
       }
     },
@@ -56,9 +71,15 @@
         "url": {
           "raw": "http://localhost:3000/holdings/orders/alice",
           "protocol": "http",
-          "host": ["localhost"],
+          "host": [
+            "localhost"
+          ],
           "port": "3000",
-          "path": ["holdings", "orders", "alice"]
+          "path": [
+            "holdings",
+            "orders",
+            "alice"
+          ]
         }
       }
     },
@@ -69,9 +90,37 @@
         "url": {
           "raw": "http://localhost:3000/market/prices",
           "protocol": "http",
-          "host": ["localhost"],
+          "host": [
+            "localhost"
+          ],
           "port": "3000",
-          "path": ["market", "prices"]
+          "path": [
+            "market",
+            "prices"
+          ]
+        }
+      }
+    },
+    {
+      "name": "List holdings",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "http://localhost:3000/holdings?user=alice",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "holdings"
+          ],
+          "query": [
+            {
+              "key": "user",
+              "value": "alice"
+            }
+          ]
         }
       }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,3 +45,14 @@ impl From<crate::holdings::StoreError> for AppError {
         }
     }
 }
+
+impl From<crate::holdings_service::HoldingsError> for AppError {
+    fn from(err: crate::holdings_service::HoldingsError) -> Self {
+        match err {
+            crate::holdings_service::HoldingsError::NoHoldings(user) => {
+                AppError::not_found(format!("no holdings for user {user}"))
+            }
+            crate::holdings_service::HoldingsError::Other(e) => AppError::internal(e.to_string()),
+        }
+    }
+}

--- a/src/holdings_service.rs
+++ b/src/holdings_service.rs
@@ -1,0 +1,277 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Context;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::sync::{Mutex, RwLock};
+use tracing::info;
+
+#[derive(Debug, Error)]
+pub enum HoldingsError {
+    #[error("no holdings for user {0}")]
+    NoHoldings(String),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HoldingRecord {
+    pub user: String,
+    pub symbol: String,
+    pub quantity: i64,
+    pub original_price: f64,
+    pub current_price: f64,
+    pub updated_at: String,
+}
+
+fn holdings_schema() -> arrow_schema::Schema {
+    use arrow_schema::{DataType, Field, Schema};
+    Schema::new(vec![
+        Field::new("user", DataType::Utf8, false),
+        Field::new("symbol", DataType::Utf8, false),
+        Field::new("quantity", DataType::Int64, false),
+        Field::new("original_price", DataType::Float64, false),
+        Field::new("current_price", DataType::Float64, false),
+        Field::new("updated_at", DataType::Utf8, false),
+    ])
+}
+
+fn records_to_batch(records: &[HoldingRecord]) -> anyhow::Result<arrow_array::RecordBatch> {
+    use arrow_array::{Float64Array, Int64Array, RecordBatch, StringArray};
+    use std::sync::Arc as SyncArc;
+
+    let schema = SyncArc::new(holdings_schema());
+    let user_array = StringArray::from_iter_values(records.iter().map(|r| r.user.as_str()));
+    let symbol_array = StringArray::from_iter_values(records.iter().map(|r| r.symbol.as_str()));
+    let qty_array = Int64Array::from_iter_values(records.iter().map(|r| r.quantity));
+    let orig_array = Float64Array::from_iter_values(records.iter().map(|r| r.original_price));
+    let curr_array = Float64Array::from_iter_values(records.iter().map(|r| r.current_price));
+    let date_array = StringArray::from_iter_values(records.iter().map(|r| r.updated_at.as_str()));
+
+    Ok(RecordBatch::try_new(
+        schema,
+        vec![
+            SyncArc::new(user_array),
+            SyncArc::new(symbol_array),
+            SyncArc::new(qty_array),
+            SyncArc::new(orig_array),
+            SyncArc::new(curr_array),
+            SyncArc::new(date_array),
+        ],
+    )?)
+}
+
+fn batch_to_records(batch: &arrow_array::RecordBatch) -> Vec<HoldingRecord> {
+    use arrow_array::{Float64Array, Int64Array, StringArray};
+
+    let user_array = batch.column(0).as_any().downcast_ref::<StringArray>().unwrap();
+    let symbol_array = batch.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+    let qty_array = batch.column(2).as_any().downcast_ref::<Int64Array>().unwrap();
+    let orig_array = batch.column(3).as_any().downcast_ref::<Float64Array>().unwrap();
+    let curr_array = batch.column(4).as_any().downcast_ref::<Float64Array>().unwrap();
+    let date_array = batch.column(5).as_any().downcast_ref::<StringArray>().unwrap();
+
+    (0..batch.num_rows())
+        .map(|i| HoldingRecord {
+            user: user_array.value(i).to_string(),
+            symbol: symbol_array.value(i).to_string(),
+            quantity: qty_array.value(i),
+            original_price: orig_array.value(i),
+            current_price: curr_array.value(i),
+            updated_at: date_array.value(i).to_string(),
+        })
+        .collect()
+}
+
+#[derive(Clone)]
+pub struct HoldingsService {
+    data_dir: PathBuf,
+    inner: Arc<RwLock<HashMap<String, Vec<HoldingRecord>>>>,
+    fs_lock: Arc<Mutex<()>>,
+}
+
+impl HoldingsService {
+    pub fn new(data_dir: PathBuf) -> Self {
+        Self {
+            data_dir,
+            inner: Arc::new(RwLock::new(HashMap::new())),
+            fs_lock: Arc::new(Mutex::new(())),
+        }
+    }
+
+    pub async fn add_or_update(&self, record: HoldingRecord) -> Result<(), HoldingsError> {
+        {
+            let mut map = self.inner.write().await;
+            let recs = map.entry(record.user.clone()).or_default();
+            if let Some(existing) = recs.iter_mut().find(|r| {
+                r.symbol == record.symbol
+                    && (r.original_price - record.original_price).abs() < f64::EPSILON
+                    && r.quantity == record.quantity
+                    && r.updated_at == record.updated_at
+            }) {
+                existing.current_price = record.current_price;
+                info!(
+                    user = %record.user,
+                    symbol = %record.symbol,
+                    price = record.current_price,
+                    "updated holding"
+                );
+            } else {
+                recs.push(record.clone());
+                info!(
+                    user = %record.user,
+                    symbol = %record.symbol,
+                    quantity = record.quantity,
+                    price = record.current_price,
+                    "added holding"
+                );
+            }
+        }
+        self.write_user_file(&record.user)
+            .await
+            .context("failed to persist holding")?;
+        Ok(())
+    }
+
+    pub async fn all_holdings(&self) -> Vec<HoldingRecord> {
+        let map = self.inner.read().await;
+        map.values().flatten().cloned().collect()
+    }
+
+    pub async fn holdings_for_user(&self, user: &str) -> Result<Vec<HoldingRecord>, HoldingsError> {
+        {
+            let map = self.inner.read().await;
+            if let Some(recs) = map.get(user) {
+                return Ok(recs.clone());
+            }
+        }
+
+        let loaded = self.read_user_file(user)
+            .await
+            .with_context(|| format!("failed to load holdings for {user}"))?;
+        if loaded.is_empty() {
+            return Err(HoldingsError::NoHoldings(user.to_string()));
+        }
+
+        let mut map = self.inner.write().await;
+        map.insert(user.to_string(), loaded.clone());
+        Ok(loaded)
+    }
+
+    async fn write_user_file(&self, user: &str) -> anyhow::Result<()> {
+        use parquet::arrow::ArrowWriter;
+        use std::fs::{create_dir_all, File};
+
+        let _lock = self.fs_lock.lock().await;
+        let user_dir = self.data_dir.join(user);
+        create_dir_all(&user_dir)?;
+        let file_path = user_dir.join("holdings.parquet");
+
+        let map = self.inner.read().await;
+        let recs = map.get(user).cloned().unwrap_or_default();
+        drop(map);
+
+        let batch = records_to_batch(&recs)?;
+        let file = File::create(file_path)?;
+        let mut writer = ArrowWriter::try_new(file, batch.schema(), None)?;
+        writer.write(&batch)?;
+        writer.close()?;
+        Ok(())
+    }
+
+    async fn read_user_file(&self, user: &str) -> anyhow::Result<Vec<HoldingRecord>> {
+        use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+        use std::fs::File;
+
+        let file_path = self.data_dir.join(user).join("holdings.parquet");
+        if !file_path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let _lock = self.fs_lock.lock().await;
+        let file = File::open(file_path)?;
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+        let mut reader = builder.build()?;
+        let mut recs = Vec::new();
+        while let Some(batch) = reader.next() {
+            let batch = batch?;
+            recs.extend(batch_to_records(&batch));
+        }
+        Ok(recs)
+    }
+
+    pub async fn update_from_market(
+        &self,
+        orders: &[crate::holdings::Order],
+        prices: &HashMap<String, crate::market::PriceInfo>,
+    ) -> Result<(), HoldingsError> {
+        for order in orders {
+            if let Some(info) = prices.get(&order.symbol) {
+                if let Some(last) = info.history.last() {
+                    let date = DateTime::<Utc>::from_timestamp(last.timestamp, 0)
+                        .expect("invalid timestamp")
+                        .date_naive()
+                        .to_string();
+                    let record = HoldingRecord {
+                        user: order.user.clone(),
+                        symbol: order.symbol.clone(),
+                        quantity: order.amount,
+                        original_price: order.price,
+                        current_price: last.close,
+                        updated_at: date,
+                    };
+                    self.add_or_update(record).await?;
+                    info!(user = %order.user, symbol = %order.symbol, "holdings updated from market");
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::holdings::Order;
+    use crate::market::PriceInfo;
+    use yahoo_finance_api::Quote;
+    use tempfile::tempdir;
+
+    fn quote(price: f64, ts: i64) -> Quote {
+        Quote { timestamp: ts, open: price, high: price, low: price, volume: 0, close: price, adjclose: price }
+    }
+
+    #[tokio::test]
+    async fn test_add_or_update() {
+        let dir = tempdir().unwrap();
+        let service = HoldingsService::new(dir.path().to_path_buf());
+
+        let orders = vec![Order { user: "u".into(), symbol: "A".into(), amount: 1, price: 10.0 }];
+        let mut prices = HashMap::new();
+        prices.insert("A".into(), PriceInfo { history: vec![quote(12.0, 0)] });
+        service.update_from_market(&orders, &prices).await.unwrap();
+        {
+            let all = service.all_holdings().await;
+            assert_eq!(all.len(), 1);
+            assert_eq!(all[0].current_price, 12.0);
+        }
+
+        // same day should update not add
+        let mut prices = HashMap::new();
+        prices.insert("A".into(), PriceInfo { history: vec![quote(13.0, 0)] });
+        service.update_from_market(&orders, &prices).await.unwrap();
+        let all = service.all_holdings().await;
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].current_price, 13.0);
+
+        // new day -> new record
+        let mut prices = HashMap::new();
+        prices.insert("A".into(), PriceInfo { history: vec![quote(14.0, 86_400)] });
+        service.update_from_market(&orders, &prices).await.unwrap();
+        let all = service.all_holdings().await;
+        assert_eq!(all.len(), 2);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,15 @@ mod holdings;
 mod error;
 mod market;
 mod state;
+mod holdings_service;
 
 use axum::{routing::{get, post}, Router, response::IntoResponse, extract::{Path, State}, Json};
 use tokio::net::TcpListener;
 use std::path::PathBuf;
 use std::sync::Arc;
+use tracing::info;
 use holdings::{HoldingStore, OrderRequest};
+use holdings_service::HoldingsService;
 use market::{MarketData, YahooFetcher};
 use error::AppError;
 use state::AppState;
@@ -42,6 +45,23 @@ async fn list_orders_for_user(
     Ok(Json(orders).into_response())
 }
 
+#[derive(serde::Deserialize)]
+struct HoldingsQuery {
+    user: Option<String>,
+}
+
+async fn list_holdings(
+    State(state): State<AppState>,
+    axum::extract::Query(query): axum::extract::Query<HoldingsQuery>,
+) -> Result<impl IntoResponse, AppError> {
+    let records = if let Some(user) = query.user {
+        state.holdings.holdings_for_user(&user).await?
+    } else {
+        state.holdings.all_holdings().await
+    };
+    Ok(Json(records))
+}
+
 async fn market_prices(State(state): State<AppState>) -> impl IntoResponse {
     let prices = state.market.prices().await;
     Json(prices)
@@ -49,24 +69,27 @@ async fn market_prices(State(state): State<AppState>) -> impl IntoResponse {
 
 #[tokio::main]
 async fn main() {
+    tracing_subscriber::fmt::init();
     let store = HoldingStore::new(PathBuf::from("data"));
+    let holdings_service = HoldingsService::new(PathBuf::from("data"));
     let fetcher = Arc::new(YahooFetcher::new().expect("failed to create fetcher"));
     let market = Arc::new(MarketData::new(fetcher, PathBuf::from("data/market")));
 
-    let state = AppState { store: store.clone(), market: market.clone() };
+    let state = AppState { store: store.clone(), market: market.clone(), holdings: holdings_service.clone() };
 
-    tokio::spawn(market.clone().run(store.clone()));
+    tokio::spawn(market.clone().run(store.clone(), holdings_service.clone()));
 
     let app = Router::new()
         .route("/", get(hello))
         .route("/holdings/transaction", post(add_transaction))
         .route("/holdings/orders", get(list_orders))
         .route("/holdings/orders/:user", get(list_orders_for_user))
+        .route("/holdings", get(list_holdings))
         .route("/market/prices", get(market_prices))
         .with_state(state);
 
     let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();
-    println!("listening on {}", listener.local_addr().unwrap());
+    info!("listening on {}", listener.local_addr().unwrap());
     axum::serve(listener, app).await.unwrap();
 }
 
@@ -75,6 +98,7 @@ mod tests {
     use super::*;
     use axum::http::{Request, StatusCode};
     use holdings::Order;
+    use holdings_service::HoldingsService;
     use market::{MarketData, QuoteFetcher};
     use state::AppState;
     use async_trait::async_trait;
@@ -111,7 +135,8 @@ mod tests {
         }
         let market_dir = dir.path().join("market");
         let market = Arc::new(MarketData::new(Arc::new(DummyFetcher), market_dir));
-        let state = AppState { store: store.clone(), market };
+        let holdings = HoldingsService::new(dir.path().to_path_buf());
+        let state = AppState { store: store.clone(), market, holdings: holdings.clone() };
         let app = Router::new()
             .route("/holdings/transaction", post(add_transaction))
             .route("/holdings/orders", get(list_orders))
@@ -180,7 +205,8 @@ mod tests {
         }
         let market_dir = dir.path().join("market");
         let market = Arc::new(MarketData::new(Arc::new(DummyFetcher), market_dir));
-        let state = AppState { store: store.clone(), market };
+        let holdings = HoldingsService::new(dir.path().to_path_buf());
+        let state = AppState { store: store.clone(), market, holdings: holdings.clone() };
         let app = Router::new()
             .route("/holdings/transaction", post(add_transaction))
             .with_state(state);
@@ -221,8 +247,9 @@ mod tests {
 
         let market_dir = dir.path().join("market");
         let market = Arc::new(MarketData::new(Arc::new(MockFetcher), market_dir));
-        let state = AppState { store: store.clone(), market: market.clone() };
-        market.update(&store).await.unwrap();
+        let holdings = HoldingsService::new(dir.path().to_path_buf());
+        let state = AppState { store: store.clone(), market: market.clone(), holdings: holdings.clone() };
+        market.update(&store, &holdings).await.unwrap();
 
         let app = Router::new()
             .route("/market/prices", get(market_prices))
@@ -236,5 +263,42 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let prices: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(prices["AAPL"], 10.0);
+    }
+
+    #[tokio::test]
+    async fn test_holdings_endpoint() {
+        let dir = tempdir().unwrap();
+        let store = HoldingStore::new(dir.path().to_path_buf());
+        let holdings = HoldingsService::new(dir.path().to_path_buf());
+        store
+            .add_order(Order { user: "alice".into(), symbol: "AAPL".into(), amount: 1, price: 1.0 })
+            .await
+            .unwrap();
+
+        struct MockFetcher;
+        #[async_trait]
+        impl QuoteFetcher for MockFetcher {
+            async fn fetch_quotes(&self, _symbol: &str) -> anyhow::Result<Vec<Quote>> {
+                Ok(vec![Quote { timestamp: 0, open: 10.0, high: 10.0, low: 10.0, volume: 0, close: 10.0, adjclose: 10.0 }])
+            }
+        }
+
+        let market_dir = dir.path().join("market");
+        let market = Arc::new(MarketData::new(Arc::new(MockFetcher), market_dir));
+        let state = AppState { store: store.clone(), market: market.clone(), holdings: holdings.clone() };
+        market.update(&store, &holdings).await.unwrap();
+
+        let app = Router::new()
+            .route("/holdings", get(list_holdings))
+            .with_state(state);
+
+        let response = app
+            .oneshot(Request::builder().uri("/holdings?user=alice").body(axum::body::Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let recs: Vec<crate::holdings_service::HoldingRecord> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(recs.len(), 1);
     }
 }

--- a/src/market.rs
+++ b/src/market.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
+use anyhow::Context;
 
 use axum::async_trait;
 use tokio::sync::RwLock;
@@ -143,13 +144,17 @@ impl MarketData {
         Ok(prices)
     }
 
-    /// Refresh quotes for all symbols held in `store`.
-    pub async fn update(&self, store: &HoldingStore) -> anyhow::Result<()> {
+    /// Refresh quotes for all symbols held in `store` and record holdings.
+    pub async fn update(
+        &self,
+        store: &HoldingStore,
+        holdings: &crate::holdings_service::HoldingsService,
+    ) -> anyhow::Result<()> {
         let orders = store.all_orders().await;
-        let symbols: HashSet<_> = orders.into_iter().map(|o| o.symbol).collect();
+        let symbols: HashSet<_> = orders.iter().map(|o| o.symbol.clone()).collect();
 
         let mut map = HashMap::new();
-        for sym in symbols {
+        for sym in symbols.clone() {
             let quotes = self.fetcher.fetch_quotes(&sym).await?;
             if let Some(last) = quotes.last() {
                 let date = DateTime::<Utc>::from_timestamp(last.timestamp, 0)
@@ -167,7 +172,13 @@ impl MarketData {
         }
 
         let mut guard = self.inner.write().await;
-        *guard = map;
+        *guard = map.clone();
+        drop(guard);
+
+        holdings
+            .update_from_market(&orders, &map)
+            .await
+            .context("failed to update holdings")?;
         Ok(())
     }
 
@@ -181,16 +192,21 @@ impl MarketData {
     }
 
     /// Get list of currently tracked symbols.
+    #[allow(dead_code)]
     pub async fn symbols(&self) -> Vec<String> {
         let guard = self.inner.read().await;
         guard.keys().cloned().collect()
     }
 
     /// Run a loop updating quotes periodically.
-    pub async fn run(self: Arc<Self>, store: HoldingStore) {
+    pub async fn run(
+        self: Arc<Self>,
+        store: HoldingStore,
+        holdings: crate::holdings_service::HoldingsService,
+    ) {
         use tokio::time::{sleep, Duration};
         loop {
-            let _ = self.update(&store).await;
+            let _ = self.update(&store, &holdings).await;
             sleep(Duration::from_secs(UPDATE_INTERVAL_SECS)).await;
         }
     }
@@ -257,8 +273,9 @@ mod tests {
         quotes.insert("MSFT".into(), vec![sample_quote(20.0)]);
         let fetcher = Arc::new(MockFetcher { data: quotes });
         let market_dir = dir.path().join("market");
+        let holdings = crate::holdings_service::HoldingsService::new(dir.path().to_path_buf());
         let market = MarketData::new(fetcher, market_dir);
-        market.update(&store).await.unwrap();
+        market.update(&store, &holdings).await.unwrap();
 
         let prices = market.prices().await;
         assert_eq!(prices.get("AAPL"), Some(&10.0));
@@ -282,10 +299,11 @@ mod tests {
         let day2 = vec![Quote { timestamp: 86_400, open: 0.0, high: 0.0, low: 0.0, volume: 0, close: 12.0, adjclose: 12.0 }];
         let fetcher = Arc::new(SeqFetcher { data: std::sync::Mutex::new(std::collections::VecDeque::from(vec![day1, day2])) });
         let market_dir = dir.path().join("market");
+        let holdings = crate::holdings_service::HoldingsService::new(dir.path().to_path_buf());
         let market = MarketData::new(fetcher, market_dir.clone());
 
-        market.update(&store).await.unwrap();
-        market.update(&store).await.unwrap();
+        market.update(&store, &holdings).await.unwrap();
+        market.update(&store, &holdings).await.unwrap();
 
         let history = market.read_symbol_file("AAPL").await.unwrap();
         assert_eq!(history.len(), 2);

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,10 +1,12 @@
 use std::sync::Arc;
 
 use crate::holdings::HoldingStore;
+use crate::holdings_service::HoldingsService;
 use crate::market::MarketData;
 
 #[derive(Clone)]
 pub struct AppState {
     pub store: HoldingStore,
     pub market: Arc<MarketData>,
+    pub holdings: HoldingsService,
 }


### PR DESCRIPTION
## Summary
- implement `HoldingsService` for tracking user holdings
- update `MarketData` to record holdings on every price refresh
- expose `GET /holdings` endpoint
- document new endpoint and update instructions
- extend Postman collection
- add comprehensive tests
- silence a dead code warning in `MarketData`
- add log output for holdings updates

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6848cf4de6548320a5a0de57af17738b